### PR TITLE
Add role-based login page with local storage authentication

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,9 @@
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import {
+  BrowserRouter,
+  Routes,
+  Route,
+  Navigate,
+} from "react-router-dom";
 import AdminLayout from "./layouts/AdminLayout";
 import Dashboard from "./pages/Dashboard/Dashboard";
 import UsersPage from "./pages/Users/Users";
@@ -6,25 +11,52 @@ import FeedbacksPage from "./pages/Feedbacks/FeedbacksPage";
 import WorkerHoursPage from "./pages/WorkerHours/WorkerHours";
 import Uploads from "./pages/Uploads/Uploads";
 import DisconnectTelegramPage from "./pages/Disconnect/DisconnectTelegramPage";
+import Login from "./pages/Login/Login";
+import { isAuthenticated } from "./utils/auth";
+
+function ProtectedRoute({ element }: { element: JSX.Element }) {
+  return isAuthenticated() ? (
+    <AdminLayout>{element}</AdminLayout>
+  ) : (
+    <Navigate to="/login" replace />
+  );
+}
 
 function App() {
   return (
     <BrowserRouter>
-      <AdminLayout>
-        <Routes>
-          <Route path="/" element={<Dashboard />} />
-          <Route path="/users" element={<UsersPage />} />
-          <Route path="/feedbacks" element={<FeedbacksPage />} />
-          <Route path="/worker-hours" element={<WorkerHoursPage />} />
-          <Route path="/uploads" element={<Uploads />} />
-          <Route
-            path="/disconnect-telegram"
-            element={<DisconnectTelegramPage />}
-          />
-        </Routes>
-      </AdminLayout>
+      <Routes>
+        <Route
+          path="/login"
+          element={
+            isAuthenticated() ? <Navigate to="/" replace /> : <Login />
+          }
+        />
+        <Route path="/" element={<ProtectedRoute element={<Dashboard />} />} />
+        <Route
+          path="/users"
+          element={<ProtectedRoute element={<UsersPage />} />}
+        />
+        <Route
+          path="/feedbacks"
+          element={<ProtectedRoute element={<FeedbacksPage />} />}
+        />
+        <Route
+          path="/worker-hours"
+          element={<ProtectedRoute element={<WorkerHoursPage />} />}
+        />
+        <Route
+          path="/uploads"
+          element={<ProtectedRoute element={<Uploads />} />}
+        />
+        <Route
+          path="/disconnect-telegram"
+          element={<ProtectedRoute element={<DisconnectTelegramPage />} />}
+        />
+      </Routes>
     </BrowserRouter>
   );
 }
 
 export default App;
+

--- a/src/layouts/AuthLayout.tsx
+++ b/src/layouts/AuthLayout.tsx
@@ -1,0 +1,19 @@
+import { Box, Container } from "@mui/material";
+import { type ReactNode } from "react";
+
+export default function AuthLayout({ children }: { children: ReactNode }) {
+  return (
+    <Box
+      sx={{
+        minHeight: "100vh",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        bgcolor: "background.default",
+      }}
+    >
+      <Container maxWidth="xs">{children}</Container>
+    </Box>
+  );
+}
+

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -1,0 +1,97 @@
+import { useState, useEffect, type FormEvent } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  Box,
+  Button,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Paper,
+  Select,
+  TextField,
+  Typography,
+} from "@mui/material";
+import AuthLayout from "../../layouts/AuthLayout";
+import {
+  authenticate,
+  isAuthenticated,
+  type Role,
+  roleOptions,
+} from "../../utils/auth";
+
+export default function Login() {
+  const [role, setRole] = useState<Role | "">("");
+  const [login, setLogin] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (isAuthenticated()) {
+      navigate("/");
+    }
+  }, [navigate]);
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    if (role && authenticate(role, login, password)) {
+      navigate("/");
+    } else {
+      setError("Invalid credentials");
+    }
+  };
+
+  return (
+    <AuthLayout>
+      <Paper elevation={3} sx={{ p: 4 }}>
+        <Typography variant="h5" mb={2} textAlign="center">
+          Sign In
+        </Typography>
+        <Box component="form" onSubmit={handleSubmit}>
+          <FormControl fullWidth margin="normal">
+            <InputLabel id="role-label">Role</InputLabel>
+            <Select
+              labelId="role-label"
+              label="Role"
+              value={role}
+              onChange={(e) => setRole(e.target.value as Role)}
+              required
+            >
+              {roleOptions.map((r) => (
+                <MenuItem key={r.value} value={r.value}>
+                  {r.label}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <TextField
+            label="Login"
+            fullWidth
+            margin="normal"
+            value={login}
+            onChange={(e) => setLogin(e.target.value)}
+            required
+          />
+          <TextField
+            label="Password"
+            type="password"
+            fullWidth
+            margin="normal"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+          />
+          {error && (
+            <Typography color="error" variant="body2" mt={1}>
+              {error}
+            </Typography>
+          )}
+          <Button type="submit" variant="contained" fullWidth sx={{ mt: 2 }}>
+            Login
+          </Button>
+        </Box>
+      </Paper>
+    </AuthLayout>
+  );
+}
+

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,0 +1,43 @@
+export type Role = "admin" | "superAdmin" | "manager";
+
+interface Credentials {
+  login: string;
+  password: string;
+}
+
+const USERS: Record<Role, Credentials> = {
+  admin: { login: "Fikret", password: "admin123!" },
+  superAdmin: { login: "Super Admin", password: "superDisabled123!" },
+  manager: { login: "Temur", password: "manager123!" },
+};
+
+const STORAGE_KEY = "authUser";
+
+export function authenticate(role: Role, login: string, password: string) {
+  const creds = USERS[role];
+  if (creds.login === login && creds.password === password) {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ role, login }));
+    return true;
+  }
+  return false;
+}
+
+export function getCurrentUser() {
+  const raw = localStorage.getItem(STORAGE_KEY);
+  return raw ? JSON.parse(raw) : null;
+}
+
+export function isAuthenticated() {
+  return Boolean(getCurrentUser());
+}
+
+export function logout() {
+  localStorage.removeItem(STORAGE_KEY);
+}
+
+export const roleOptions = [
+  { value: "admin", label: "Admin" },
+  { value: "superAdmin", label: "Super Admin" },
+  { value: "manager", label: "Manager" },
+];
+


### PR DESCRIPTION
## Summary
- implement role-based login page for Admin, Super Admin, and Manager with static credentials stored in localStorage
- add auth utilities and layout for login flow
- protect existing routes and redirect to login when unauthenticated

## Testing
- `npm run lint` *(fails: Unexpected any / unused vars in existing code)*

------
https://chatgpt.com/codex/tasks/task_e_68b6ba05a630832e9b69375b1b75c54a